### PR TITLE
Potential fix for code scanning alert no. 53: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/netOperationController.js
+++ b/backend/src/controllers/netOperationController.js
@@ -89,9 +89,23 @@ exports.updateNetOperation = async (req, res) => {
       return res.status(403).json({ error: 'Not authorized to update this net operation' });
     }
 
+    // Only allow specific fields to be updated
+    const allowedFields = ['netName', 'frequency', 'notes', 'status'];
+    const update = {};
+    for (const key of allowedFields) {
+      if (req.body.hasOwnProperty(key)) {
+        update[key] = req.body[key];
+      }
+    }
+    // Detect update operators injection
+    for (const key in req.body) {
+      if (key.startsWith('$')) {
+        return res.status(400).json({ error: 'Update operators are not allowed' });
+      }
+    }
     const updatedNetOperation = await NetOperation.findByIdAndUpdate(
       req.params.id,
-      req.body,
+      update,
       { new: true, runValidators: true }
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/crypiehef/NetControlAPP/security/code-scanning/53](https://github.com/crypiehef/NetControlAPP/security/code-scanning/53)

The best way to fix the problem is to sanitize and strictly control which fields from `req.body` are used to update the document. Rather than passing the entire user-controlled `req.body` to Mongoose, you should build an update object explicitly from expected fields (e.g., `netName`, `frequency`, `notes`, `status`) and ignore any other properties, especially those starting with `$`. Additionally, you can reject any attempt to send update operators in the body. To implement this, in `backend/src/controllers/netOperationController.js`, inside the `updateNetOperation` controller, replace the direct usage of `req.body` with a constructed update object comprised solely of intended fields. Optionally, you can add a check to ensure the user is not trying to inject update operators.

This fix does not require extra dependencies, but will involve code changes to explicitly whitelist fields from `req.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
