### PR TITLE
Security: upgrade vite (frontend) + brace-expansion (backend)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1995,7 +1995,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "date-fns": "^2.30.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.0.0"
+    "@vitejs/plugin-react": "^4.6.0",
+    "vite": "^6.4.3"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Remediates the remaining open security findings not covered by Dependabot's own PRs.

## Frontend — vite (2 Dependabot alerts: #72 high, #73 medium)
- `vite` `^5.0.0` → `^6.4.3`, `@vitejs/plugin-react` `^4.2.0` → `^4.6.0`
- Fixes **GHSA-fx2h-pf6j-xcff** (`server.fs.deny` bypass on Windows) and **GHSA-v6wh-96g9-6wx3** (launch-editor NTLMv2 hash disclosure).
- The advisory has **no patched release in the vite 5.x line** — the entire `<= 6.4.2` range is vulnerable, first fixed in 6.4.3 — so a major bump is required. `@vitejs/plugin-react` was bumped to a vite-6-compatible version (peer `^4 || ^5 || ^6`).
- ✅ Production build verified: `vite build` succeeds (471 modules, clean dist).

## Backend — brace-expansion (npm audit, transitive)
- Transitive `brace-expansion` → `1.1.15` (lockfile only) fixing **GHSA-f886-m6hf-6m8v** (ReDoS / process hang).
- `npm audit` in `backend/` is now clean (0 vulnerabilities).

Frontend has no tracked `package-lock.json` (matching existing repo convention), so only `frontend/package.json` is changed there.